### PR TITLE
[refactor] 전역 핸들러에 authexception 추가

### DIFF
--- a/src/main/java/com/fiveguys/RIA/RIA_Backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/fiveguys/RIA/RIA_Backend/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.fiveguys.RIA.RIA_Backend.common.exception;
 
+import com.fiveguys.RIA.RIA_Backend.auth.exception.AuthException;
 import com.fiveguys.RIA.RIA_Backend.common.exception.errorcode.CommonErrorCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +10,16 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+
+    // AuthException 처리
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<ErrorResponse> handleAuthException(AuthException ex) {
+        return ResponseEntity
+            .status(ex.getErrorCode().getStatus())
+            .body(ErrorResponse.of(ex.getErrorCode()));
+    }
+
 
     //  커스텀 예외 처리 (서비스 레벨에서 던진 CustomException)
     @ExceptionHandler(CustomException.class)


### PR DESCRIPTION
<!-- 
제목 양식
[타입] 간단한 설명 (#이슈번호)
ex) [Feat] 게시글 생성 API 구현 (#23)

Feat	새로운 기능 추가
Fix	버그 수정
Refactor	코드 리팩토링
Style	스타일, 포맷 수정 (기능 변화 없음)
Chore	빌드, 설정, 패키지 등 기타 작업
Docs	문서 추가 또는 수정
Test	테스트 코드 추가/보완
-->

## 💡 작업 개요
<!-- 이번 PR에서 어떤 기능/버그를 다뤘는지 간단 요약 -->
- 비밀번호 수정시 잘못된 비밀번호를 내려줬을때 400이 아닌 500이 내려오는 상황이 발견 이를 해결하기위해 exception 코드를 수정함

</br>

## 🔨 작업 내용
<!-- 어떤 변경 사항이 있었는지 구체적으로 설명 -->
- authexception이 500으로 내려가는 상황 발생
- globalexception에 authexception.class 추가하여 전역으로 500 에러 코드를 내려보내던걸 잡아서 커스텀 메세지가 보내는걸로 수정함



</br>


## 🎯 관련 이슈
<!-- 연결된 이슈가 있다면 아래에 작성 -->
- 

</br>


## 📚 참고 자료 (선택)
<!-- 참고한 외부 문서, 링크가 있다면 작성 -->
- 
